### PR TITLE
MB-LAB: Fixed a bug with unregistering the add-on

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2220,7 +2220,7 @@ def register():
 
 def unregister():
     for cls in reversed(classes):
-        bpy.utils.register_class(cls)
+        bpy.utils.unregister_class(cls)
 
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
fixed a copy-paste error unregister_class instead of register_class

Signed-off-by: Amir Shehata <amir.shehata@gmail.com>