### PR TITLE
MB-Lab: Add the ability to delete the face rig

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1769,6 +1769,23 @@ class CreateFaceRig(bpy.types.Operator):
                         "Select finalized MB Lab character to create face rig")
         return {'FINISHED'}
 
+class DeleteFaceRig(bpy.types.Operator):
+    bl_idname = "mbast.delete_face_rig"
+    bl_label = "Delete Face Rig"
+    bl_description = "Delete the character's face Rig"
+    bl_context = 'objectmode'
+    bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
+
+    def execute(self, context):
+        mblab_shapekeys.update_expressions_data()
+        if mblab_shapekeys.model_type != "NONE":
+            if not facerig.delete_face_rig():
+                self.report({'ERROR'},
+                            "Face Rig deletion failed")
+        else:
+            self.report({'ERROR'},
+                "Select finalized MB Lab character to create face rig")
+        return {'FINISHED'}
 
 class StartSession(bpy.types.Operator):
     bl_idname = "mbast.init_character"
@@ -1848,6 +1865,7 @@ class VIEW3D_PT_tools_ManuelbastioniLAB(bpy.types.Panel):
 
             # face rig button
             self.layout.operator('mbast.create_face_rig')
+            self.layout.operator('mbast.delete_face_rig')
 
             if gui_active_panel_fin != "assets":
                 self.layout.operator('mbast.button_assets_on', icon=icon_expand)
@@ -2265,6 +2283,7 @@ classes = (
     LoadBvh,
     StartSession,
     CreateFaceRig,
+    DeleteFaceRig,
     LoadTemplate,
     VIEW3D_PT_tools_ManuelbastioniLAB,
 )


### PR DESCRIPTION
Added a button to delete the face rig. Some users might prefer to
use the expression sliders, which can not be used after drivers
have been added to the shape keys

Signed-off-by: Amir Shehata <amir.shehata@gmail.com>