### PR TITLE
when transferring weights for proxying, check the vertex is in the group

### DIFF
--- a/proxyengine.py
+++ b/proxyengine.py
@@ -73,12 +73,10 @@ class ProxyEngine:
 
 
         body_verts_weights = [[] for v in body.data.vertices]
-        for grp in body.vertex_groups:
+        for gid, grp in enumerate(body.vertex_groups):
             for idx, w_data in enumerate(body_verts_weights):
-                try:
-                    w_data.append([grp.name,grp.weight(idx)])
-                except:
-                    pass #TODO: idx in grp.weight
+                in_group = gid in [g.group for g in body.data.vertices[idx].groups]
+                w_data.append([grp.name,grp.weight(idx) if in_group else 0])
 
         for p_idx, proxy_vert in enumerate(proxy_vertices):
 


### PR DESCRIPTION
avoids an error message from blender (normally not seen, I think) and the possibility of messing up on later vertex groups since we'd otherwise skip appending to the list.

i found this problem because it was generating annoying error noise in a script i'm working on.  this seems like the right fix, to me.