### PR TITLE
Fix undefined name 'traceback' in facerig.py

### DIFF
--- a/facerig.py
+++ b/facerig.py
@@ -24,6 +24,7 @@
 import logging
 import json
 import os
+import traceback
 
 import bpy
 


### PR DESCRIPTION
https://docs.python.org/3/library/traceback.html

[flake8](http://flake8.pycqa.org) testing of https://github.com/animate1978/MB-Lab on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./facerig.py:378:13: F821 undefined name 'traceback'
            traceback.print_stack()
            ^
1     F821 undefined name 'traceback'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree