### PR TITLE
Missing import in algorithms.py added (issue #173)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1994,11 +1994,10 @@ class VIEW3D_PT_tools_MBLAB(bpy.types.Panel):
             box_face_rig.prop(scn, "mblab_facs_rig")
 
             # Humanoid Rotation Limits
-            box = self.layout.box()
-            box.label(text="Humanoid Rotations")
-            box.operator("mbast.humanoid_rot_limits", icon='USER')
-            box.operator('mbast.delete_rotations', icon='CANCEL')
-            box = self.layout.box()
+            box_hmrot = box_post_opt.box()
+            box_hmrot.label(text="Humanoid Rotations")
+            box_hmrot.operator("mbast.humanoid_rot_limits", icon='USER')
+            box_hmrot.operator('mbast.delete_rotations', icon='CANCEL')
 
 
             if gui_active_panel_fin != "expressions":
@@ -2016,7 +2015,7 @@ class VIEW3D_PT_tools_MBLAB(bpy.types.Panel):
                         for expr_name in sorted(mblab_shapekeys.expressions_data.keys()):
                             if hasattr(obj, expr_name):
                                 if scn.mblab_expression_filter in expr_name:
-                                    box.prop(obj, expr_name)
+                                    box_exp.prop(obj, expr_name)
                     box_exp.operator("mbast.reset_expression", icon="RECOVER_LAST")
                 else:
                     box_exp.enabled = False
@@ -2031,7 +2030,7 @@ class VIEW3D_PT_tools_MBLAB(bpy.types.Panel):
 
                 box_asts.prop(scn, 'mblab_proxy_library')
                 box_asts.prop(scn, 'mblab_assets_models')
-                # box.operator('mbast.load_assets_element')
+                # box_asts.operator('mbast.load_assets_element')
                 box_asts.label(text="To adapt the asset, use the proxy fitting tool", icon='INFO')
 
 

--- a/algorithms.py
+++ b/algorithms.py
@@ -33,8 +33,7 @@ import array
 import mathutils
 import bpy
 
-from . import utils
-#from .utils import get_object_parent
+from . import file_ops, utils
 
 logger = logging.getLogger(__name__)
 
@@ -368,7 +367,7 @@ def kdtree_from_mesh_vertices(mesh):
 
 def import_mesh_from_lib(lib_filepath, name):
     existing_mesh_names = collect_existing_meshes()
-    append_mesh_from_library(lib_filepath, [name])
+    file_ops.append_mesh_from_library(lib_filepath, [name])
     new_mesh = get_newest_mesh(existing_mesh_names)
     return new_mesh
 
@@ -683,7 +682,7 @@ def identify_template(obj):
         if obj.type == 'MESH':
             verts = obj.data.vertices
             polygons = obj.data.polygons
-            config_data = get_configuration()
+            config_data = file_ops.get_configuration()
             # TODO error messages
             if verts and polygons:
                 for template in config_data["templates_list"]:
@@ -696,7 +695,7 @@ def identify_template(obj):
 
 def get_template_model(obj):
     template = identify_template(obj)
-    config_data = get_configuration()
+    config_data = file_ops.get_configuration()
     if template:
         return config_data[template]["template_model"]
     return None
@@ -704,7 +703,7 @@ def get_template_model(obj):
 
 def get_template_polygons(obj):
     template = identify_template(obj)
-    config_data = get_configuration()
+    config_data = file_ops.get_configuration()
     if template:
         return config_data[template]["template_polygons"]
     return None
@@ -1088,7 +1087,7 @@ def has_deformation_vgroups(obj, armat):
 
 
 def is_rigged(obj, armat):
-    # if is_armature_linked(obj, armat):
+    # if file_ops.is_armature_linked(obj, armat):
     return has_deformation_vgroups(obj, armat)
 
 


### PR DESCRIPTION
Additional fix done for menu issue.
After some refactoring in algorithms.py, the file io methods were not imported to access configuration.
Missing import added. Small issue with not displayed face expression properties also fixed.

Warning: 
Operators "mbast.humanoid_rot_limits" and "mbast.delete_rotations" are defined in the menu, but not loaded. The author of this feature should either remove menu items or add operators to classes property in order to load them.