### PR TITLE
Fixed a bug for separated projects

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3553,6 +3553,7 @@ class VIEW3D_PT_tools_MBCrea(bpy.types.Panel):
                 if len(cleaned_name) > 0 :
                     box_compat_tools_sub.label(text="Cleaned : " + cleaned_name, icon='INFO')
                     creation_tools_ops.set_data_directory(cleaned_name)
+                    file_ops.set_data_path(cleaned_name)
                     project_creation_buttons=box_compat_tools_sub.column(align=True)
                     project_creation_buttons.operator('mbcrea.button_create_directories', icon='FREEZE')
                     project_creation_buttons.operator('mbcrea.button_create_config', icon='FREEZE')

--- a/creation_tools_ops.py
+++ b/creation_tools_ops.py
@@ -284,16 +284,16 @@ def is_blend_file_exist():
     global config_content
     if len(config_content["data_directory"]) < 1:
         return False
-    dirpath = os.path.join(file_ops.get_data_path(), config_content["data_directory"] + "_library.blend")
+    dirpath = os.path.join(file_ops.get_data_path(), "humanoid_library.blend")
     if os.path.isfile(dirpath):
         return True
     return False
 
 def get_blend_file_pathname():
-    return os.path.join(file_ops.get_data_path(), config_content["data_directory"] + "_library.blend")
+    return os.path.join(file_ops.get_data_path(), "humanoid_library.blend")
 
 def get_blend_file_name():
-    return config_content["data_directory"] + "_library.blend"
+    return "humanoid_library.blend"
 
 def load_blend_file():
     global blend_file_content
@@ -305,7 +305,7 @@ def load_blend_file():
     if is_blend_file_exist():
         lib_filepath = get_blend_file_pathname()
     else:
-        logger.critical("Blend file does not exist or is not under /data/")
+        logger.critical("Blend file does not exist or is not under /" + file_ops.get_data_path() + "/")
         return []
     # Import objects name from library
     with bpy.data.libraries.load(lib_filepath) as (data_from, data_to):


### PR DESCRIPTION
With the new "Project" separation, using the creation tools fails, as the config and blend where handled differently. Now it's good, the creator does nothing for the config, and blend must be in its dedicated folder with the good name.
By the way, this name may change in the future, I think that it's better that it has the name of the project like toon_library.blend, not just humanoid_library.blend.