### PR TITLE
Fix broken finalisation routine for Blender 2.90

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -1066,7 +1066,7 @@ def apply_modifier(obj, modifier):
     if modifier_name in obj.modifiers:
         set_active_object(obj)
         try:
-            bpy.ops.object.modifier_apply(apply_as='DATA', modifier=modifier_name)
+            bpy.ops.object.modifier_apply_as_shapekey(modifier=modifier_name)
         except AttributeError:
             logger.warning("Problems in applying %s. Is the modifier disabled?", modifier_name)
 


### PR DESCRIPTION
Some modifiers were previously applied as data.
I'm not sure why that is, and I'm not sure it is desired behaviour.
I can change this back to applying as data, but I think for the future application as a shapekey is better behaviour, allowing the user more control.
More importantly, this fixes finalisation for Blender 2.90.