### PR TITLE
Optimize calculate_disp_pixels for faster displacement calculation

### DIFF
--- a/materialengine.py
+++ b/materialengine.py
@@ -307,7 +307,8 @@ class MaterialEngine:
                     return
 
                 if images_scale(disp_data_image, disp_img):
-                    disp_img.pixels = self.calculate_disp_pixels(disp_data_image, age_factor, tone_factor, mass_factor)
+                    new_pixels = self.calculate_disp_pixels(disp_data_image, age_factor, tone_factor, mass_factor)
+                    disp_img.pixels.foreach_set(new_pixels)
                     disp_tex.image = disp_img
                     logger.info("Displacement calculated in %s seconds", time.time()-time1)
             else:

--- a/materialengine.py
+++ b/materialengine.py
@@ -155,24 +155,22 @@ class MaterialEngine:
         logger.info('start: calculate_disp_pixels %s', blender_image.name)
         tone_f = tone_factor if tone_factor > 0.0 else 0.0
 
-        ajustments = np.array([0.0, 0.5, 0.5, 0.5], dtype='float32')
-        factors = np.fmax(np.array([1, age_factor, tone_f, (1.0 - tone_f) * mass_factor], dtype='float32'), 0.0)
-        np_image = np.array(blender_image.pixels, dtype='float32').reshape(-1, 4)
+        adjustments = np.array([0.0, 0.5, 0.5, 0.5], dtype=np.float32)
+        factors = np.fmax(np.array([1, age_factor, tone_f, (1.0 - tone_f) * mass_factor], dtype=np.float32), 0.0)
+        np_image = np.empty(len(blender_image.pixels), dtype=np.float32)
+        blender_image.pixels.foreach_get(np_image)
+        np_image = np_image.reshape(-1, 4)
         # add_result = r + age_f * (g - 0.5) + tone_f * (b - 0.5) + mass_f * (a - 0.5)
-        add_result = np.sum((np_image - ajustments) * factors, axis=1)
-        result_image = np.insert(np.repeat(np.fmin(add_result, 1.0), 3).reshape(-1, 3), 3, 1.0, axis=1)
+        np_image -= adjustments
+        np_image *= factors
+        add_result = np.sum(np_image, axis=1)
+        np.fmin(add_result, 1.0, add_result)
+        np_image[:,0] = add_result
+        np_image[:,1] = add_result
+        np_image[:,2] = add_result
+        np_image[:,3] = 1
         logger.info('finish: calculate_disp_pixels %s', blender_image.name)
-        return result_image.flatten()
-
-    @staticmethod
-    def multiply_images(image1, image2, result_name, blending_factor=0.5):
-        logger.info('multiply_images %s', result_name)
-        if images_scale(image1, image2):
-            np_img1, np_img2 = np.array(image1.pixels, dtype='float32'), np.array(image2.pixels, dtype='float32')
-
-            result_img = new_image(result_name, image2.size)
-            result_img.pixels = np_img1 * np_img2 * blending_factor + (np_img1 * (1.0 - blending_factor))
-        logger.info('finish: multiply_images %s', result_name)
+        return np_image.reshape(-1)
 
 # Link Textures to Nodes
 


### PR DESCRIPTION
My displacement calculation algorithm is faster and uses less memory

1) multiply_images function doesn't seem to be used anywhere so I removed it
2) pixels.foreach_get() is much faster than np.array(pixels)
3) I use in-place array modifications such as += and *= to get rid of excessive data copying and memory allocations
4) reshape(-1) is faster than flatten() and doesn't allocate additional memory

As a result my version is 2x faster, and calculate_disp_pixels function is 18x faster

Before:
```
2021-02-01 17:50:40,307 INFO: MB-Lab.materialengine - calculate_disp_pixels - 155 - start: calculate_disp_pixels human_female_displacement.png
2021-02-01 17:50:44,805 INFO: MB-Lab.materialengine - calculate_disp_pixels - 164 - finish: calculate_disp_pixels human_female_displacement.png
2021-02-01 17:50:48,840 INFO: MB-Lab.materialengine - calculate_displacement_texture - 314 - Displacement calculated in 8.53285837173462 seconds
```
After:
```
2021-02-01 17:42:59,544 INFO: MB-Lab.materialengine - calculate_disp_pixels - 155 - start: calculate_disp_pixels human_female_displacement.png
2021-02-01 17:42:59,784 INFO: MB-Lab.materialengine - calculate_disp_pixels - 172 - finish: calculate_disp_pixels human_female_displacement.png
2021-02-01 17:43:03,849 INFO: MB-Lab.materialengine - calculate_displacement_texture - 312 - Displacement calculated in 4.30582857131958 seconds
```