### PR TITLE
commit preferences changes to enable censors and scheduled update

### DIFF
--- a/preferences.py
+++ b/preferences.py
@@ -33,40 +33,39 @@ class MBPreferences(bpy.types.AddonPreferences):
     '''
     bl_idname = __package__
     # addon updater preferences
-    auto_check_update = bpy.props.BoolProperty(
+    auto_check_update: bpy.props.BoolProperty(
         name="Auto-check for Update",
         description="If enabled, auto-check for updates using an interval",
-        default=False,
+        default=False
     )
-    updater_intrval_months = bpy.props.IntProperty(
+    updater_intrval_months: bpy.props.IntProperty(
         name='Months',
         description="Number of months between checking for updates",
         default=0,
         min=0
     )
-    updater_intrval_days = bpy.props.IntProperty(
+    updater_intrval_days: bpy.props.IntProperty(
         name='Days',
         description="Number of days between checking for updates",
         default=7,
         min=0,
         max=31
     )
-    updater_intrval_hours = bpy.props.IntProperty(
+    updater_intrval_hours: bpy.props.IntProperty(
         name='Hours',
         description="Number of hours between checking for updates",
         default=0,
         min=0,
         max=23
     )
-    updater_intrval_minutes = bpy.props.IntProperty(
+    updater_intrval_minutes: bpy.props.IntProperty(
         name='Minutes',
         description="Number of minutes between checking for updates",
         default=0,
         min=0,
         max=59
     )
-
-    use_censors = bpy.props.BoolProperty(
+    use_censors: bpy.props.BoolProperty(
         name='censors',
         description="Use censors to cover genitals and breasts",
         default=True
@@ -93,3 +92,10 @@ class MBPreferences(bpy.types.AddonPreferences):
         # col = mainrow.column()
         # col.scale_y = 2
         # col.operator("wm.url_open","Open webpage ").url=addon_updater_ops.updater.website
+
+# Registration
+def register():
+    bpy.utils.register_class(MBPreferences)
+	
+def unregister():
+    bpy.utils.unregister_class(MBPreferences)	


### PR DESCRIPTION
This is a preferences.py fix to address bugs #350 and #357 