### PR TITLE
MB-Lab 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All changes will be documented here
 
+# MB-Lab 1.8.1
+
+Final version of MB-Lab as development has moved onto Charmorph
+
+## Requirements
+
+- Requires Blender 4.0.0 +
+
+## Added
+
+- USCC CEL Shader added to Anime models
+
+## Changed
+
+## Bug Fixes
+
+## Known Issues
+
+- MB-Dev tools may contain bugs that are unknown at this time
+- Importing BVH animation files is buggy
+- Hair presets have the old PrincipledHairBSDF which will result in incorrect rendering
+- Skin color and bump mapping change slightly when finalizing
+
 # MB-Lab 1.8.0
 
 ## Requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Final version of MB-Lab as development has moved onto Charmorph
 
 ## Added
 
-- USCC CEL Shader added to Anime models
+- UCSS CEL Shader added to Anime models
 
 ## Changed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Final version of MB-Lab as development has moved onto Charmorph
 
 ### Added
 
-- USCC CEL Shader added to Anime models
+- UCSS CEL Shader added to Anime models
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ MB-Lab is a community developed project based off ManuelBastioniLAB.
 
 This fork is an attempt to keep this addon going forward as the original author is no longer developing ManuelBastioniLAB
 
-# MB-Lab 1.8.0
+# MB-Lab 1.8.1
+
+Final version of MB-Lab as development has moved onto Charmorph
 
 ## Requirements
 
@@ -24,19 +26,7 @@ This fork is an attempt to keep this addon going forward as the original author 
 
 ### Added
 
-- Melanin map added that adds variance to the skin pigment
-
-## Changed
-
-- MBLabSkin3 is a now based off of the 1.7.6 shader with modifications
-- AutoUpdater is disabled
-- SubD levels have increased for better visuals
-- Some menus rearranged for better workflow
-- Added new license types in MB-Dev, also removed AFPL due to restrictive nature
-
-## Bug Fixes
-
-- Fixed bugs in various files to make it work with Blender 4.0
+- USCC CEL Shader added to Anime models
 
 ## Known Issues
 

--- a/__init__.py
+++ b/__init__.py
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 bl_info = {
     "name": "MB-Lab",
     "author": "Manuel Bastioni, MB-Lab Community",
-    "version": (1, 8, 0),
+    "version": (1, 8, 1),
     "blender": (4, 0, 0),
     "location": "View3D > Tools > MB-Lab",
     "description": "Character creation tool based off of ManuelbastioniLAB",


### PR DESCRIPTION
# MB-Lab 1.8.1

Final version of MB-Lab as development has moved onto Charmorph

## Requirements

- MB-Lab now requires Blender 4.0.0 +

### Added

- UCSS CEL Shader added to Anime models

## Known Issues

- MB-Dev tools may contain bugs that are unknown at this time
- Importing BVH animation files is buggy
- Hair presets have the old PrincipledHairBSDF which will result in incorrect rendering
- Skin color and bump mapping change slightly when finalizing